### PR TITLE
feat: モノレポ基本設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# 依存関係
+node_modules
+.pnpm-store
+
+# ビルド出力
+dist
+build
+.next
+out
+coverage
+
+# ログ
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# 環境変数
+.env
+.env.*
+!.env.example
+
+# エディタ
+.idea
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# turbo
+.turbo 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Username Checker
+
+複数のソーシャルメディアプラットフォームやドメインにおいて、指定されたユーザー名/ドメインプレフィックスが利用可能かを確認できるWebサービスです。
+
+## 機能
+
+- ユーザー名の入力と一括チェック
+- 複数のプラットフォームでの利用可否をリアルタイム表示
+- レスポンシブなUI
+
+## 技術スタック
+
+- **共通:** TypeScript, Node.js, pnpm workspace, Turborepo, Biome, Vitest
+- **バックエンド:** Hono, Zod, Pino
+- **フロントエンド:** React, Vite, TailwindCSS, TanStack Query, Radix UI, React Hook Form
+
+## 開発環境のセットアップ
+
+### 必要条件
+
+- Node.js v20以上
+- pnpm v8以上
+
+### インストール
+
+```bash
+# リポジトリのクローン
+git clone https://github.com/fortkle/username-checker.git
+cd username-checker
+
+# 依存関係のインストール
+pnpm install
+```
+
+### 開発サーバーの起動
+
+```bash
+# 全パッケージの開発サーバーを起動
+pnpm dev
+```
+
+### テスト実行
+
+```bash
+# 全パッケージのテストを実行
+pnpm test
+```
+
+### リンターとフォーマッター
+
+```bash
+# リンター実行
+pnpm lint
+
+# フォーマッター実行
+pnpm format
+```
+
+## プロジェクト構成
+
+```
+username-checker/
+├── configs/           # 共通設定ファイル
+├── packages/
+│   ├── server-app/    # バックエンドAPI (Hono)
+│   └── web-app/       # フロントエンドUI (React)
+├── biome.json         # Biome設定
+├── turbo.json         # Turborepo設定
+└── pnpm-workspace.yaml # pnpmワークスペース設定
+```
+
+## ライセンス
+
+MIT 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.3.3/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": "error"
+      },
+      "correctness": {
+        "noUnusedVariables": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConsoleLog": "warn"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    },
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingComma": "es5",
+      "semicolons": "always"
+    }
+  }
+} 

--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "declaration": true,
+    "sourceMap": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist"]
+} 

--- a/configs/vitest.base.js
+++ b/configs/vitest.base.js
@@ -1,0 +1,14 @@
+/** @type {import('vitest').defineConfig} */
+export default {
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      reportsDirectory: './coverage'
+    },
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules/**', 'dist/**']
+  }
+}; 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "username-checker",
+  "private": true,
+  "version": "0.0.0",
+  "description": "複数のプラットフォームでユーザー名の利用可否をチェックするWebサービス",
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "test": "turbo test",
+    "lint": "turbo lint",
+    "format": "biome format --write ."
+  },
+  "packageManager": "pnpm@8.10.0",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "1.3.3",
+    "turbo": "^1.10.16"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+} 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*' 

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {},
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+    }
+  }
+} 


### PR DESCRIPTION
### 変更概要

モノレポの基本環境を設定しました。

### 変更内容

- pnpm workspaceの設定（package.json, pnpm-workspace.yaml）
- Turborepoの設定（turbo.json）
- 共通設定ファイル（configs/ 以下）
  - tsconfig.base.json: TypeScript共通設定
  - vitest.base.js: Vitest共通設定
- ルートBiome設定（biome.json）
- .gitignoreの追加
- README.mdの追加

### 確認してほしいこと

- 各設定ファイルの内容が適切か
- パッケージ構成が要件と合っているか

### 関連Issue

- Issue 1: モノレポ基本設定
