### PR TITLE
feat: server-app初期設定とヘルスチェックAPIを実装

### DIFF
--- a/Issues.md
+++ b/Issues.md
@@ -4,7 +4,7 @@
 *ユーザーストーリー: 開発者は、モノレポ構成でバックエンドとフロントエンドの基本プロジェクトをセットアップできる。*
 
 - [x] **Issue 1:** [Setup] モノレポ基本設定: pnpm workspace, Turborepo, 共通設定 (`configs/*`), ルートBiomeを設定する。 (`Plan.md` Phase 1, Step 1)
-- [ ] **Issue 2:** [Setup] `server-app` 初期設定: `@quick-start.mdc` 準拠でパッケージを作成し、基本的なヘルスチェックAPI (/health\_check) を実装する。 (`Plan.md` Phase 1, Step 2)
+- [x] **Issue 2:** [Setup] `server-app` 初期設定: `@quick-start.mdc` 準拠でパッケージを作成し、基本的なヘルスチェックAPI (/health\_check) を実装する。 (`Plan.md` Phase 1, Step 2)
 - [ ] **Issue 3:** [Setup] `web-app` 初期設定: `@quick-start.mdc` 準拠でパッケージを作成し、React, TailwindCSS, TanStack Query, React Hook Form, Zod 等の基本設定を行い、"Hello World" を表示する。 (`Plan.md` Phase 1, Step 3)
 - [ ] **Issue 4:** [Setup] 初期リンター/フォーマッター適用: `pnpm lint`, `pnpm format` を実行し、初期コードに問題がないことを確認する。 (`Plan.md` Phase 1, Step 4)
 - [ ] **Issue 5:** [PR] Epic 1 PR作成: 開発基盤構築完了のプルリクエストを作成する。 (`Plan.md` Phase 1, Step 5)

--- a/packages/server-app/package.json
+++ b/packages/server-app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "server-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "biome check .",
+    "lint:fix": "biome check --apply .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.1",
+    "hono": "^4.0.0",
+    "pino": "^8.15.0",
+    "pino-pretty": "^10.2.0",
+    "zod": "^3.22.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.6.0",
+    "tsx": "^3.12.8",
+    "typescript": "^5.2.2",
+    "vitest": "^0.34.3"
+  }
+}

--- a/packages/server-app/src/index.ts
+++ b/packages/server-app/src/index.ts
@@ -1,0 +1,24 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { logger } from './utils/logger.js';
+import { healthCheckRouter } from './routers/health-check.js';
+
+// アプリケーションの作成
+const app = new Hono();
+
+// ルーターの設定
+app.route('/health_check', healthCheckRouter);
+
+// サーバー起動
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 8787;
+
+type ServerInfo = {
+  port: number;
+};
+
+serve({
+  fetch: app.fetch,
+  port: PORT,
+}, (info: ServerInfo) => {
+  logger.info(`Server is running on port ${info.port}`);
+}); 

--- a/packages/server-app/src/routers/health-check.test.ts
+++ b/packages/server-app/src/routers/health-check.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { healthCheckRouter } from './health-check.js';
+
+describe('Health Check API', () => {
+  it('should return status ok with timestamp and version', async () => {
+    // ルーターからレスポンスを取得
+    const res = await healthCheckRouter.request('/');
+    expect(res.status).toBe(200);
+    
+    // レスポンスのJSONを解析
+    const data = await res.json();
+    
+    // 期待する構造と型を持っているか確認
+    expect(data).toHaveProperty('status', 'ok');
+    expect(data).toHaveProperty('timestamp');
+    expect(data).toHaveProperty('version');
+    
+    // timestampが有効なISO日付文字列か確認
+    expect(new Date(data.timestamp).toISOString()).toBe(data.timestamp);
+  });
+}); 

--- a/packages/server-app/src/routers/health-check.ts
+++ b/packages/server-app/src/routers/health-check.ts
@@ -1,0 +1,30 @@
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { z } from 'zod';
+import { logger } from '../utils/logger.js';
+
+// レスポンススキーマの定義
+const healthCheckResponseSchema = z.object({
+  status: z.literal('ok'),
+  timestamp: z.string(),
+  version: z.string(),
+});
+
+// 型の推論
+type HealthCheckResponse = z.infer<typeof healthCheckResponseSchema>;
+
+// ヘルスチェックルーター
+export const healthCheckRouter = new Hono();
+
+// ヘルスチェックエンドポイント
+healthCheckRouter.get('/', (c: Context) => {
+  logger.info('Health check requested');
+  
+  const response: HealthCheckResponse = {
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    version: process.env.npm_package_version || '0.0.0',
+  };
+  
+  return c.json(response);
+}); 

--- a/packages/server-app/src/utils/logger.ts
+++ b/packages/server-app/src/utils/logger.ts
@@ -1,0 +1,13 @@
+import pino from 'pino';
+
+// ロガー設定
+export const logger = pino({
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      colorize: true,
+      translateTime: 'SYS:standard',
+    },
+  },
+  level: process.env.LOG_LEVEL || 'info',
+}); 

--- a/packages/server-app/tsconfig.json
+++ b/packages/server-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../configs/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ESNext"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+} 

--- a/packages/server-app/vitest.config.ts
+++ b/packages/server-app/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import vitestBaseConfig from '../../configs/vitest.base.js';
+
+export default mergeConfig(
+  vitestBaseConfig,
+  defineConfig({
+    test: {
+      environment: 'node',
+    },
+  })
+); 


### PR DESCRIPTION
### 変更概要

server-appパッケージを追加し、基本的なヘルスチェックAPIを実装しました。

### 変更内容

- packages/server-app パッケージの作成
- TypeScript、Hono、Vitest の設定
- ヘルスチェックAPIルーターの実装
- テストケース作成
- pino ロガーセットアップ
- Issue 2 をチェック済みとしてマーク

### 確認してほしいこと

- server-appの基本構造が要件に合っているか
- ヘルスチェックAPIのレスポンス形式
- テストの内容が適切か

### 関連Issue

- Issue 2:  初期設定
